### PR TITLE
Updated PaginationType to allow custom fields to be injected

### DIFF
--- a/src/Rebing/GraphQL/Support/PaginationType.php
+++ b/src/Rebing/GraphQL/Support/PaginationType.php
@@ -12,14 +12,22 @@ class PaginationType extends ObjectType {
     public function __construct($typeName, $customName = null)
     {
         $name = $customName ?: $typeName . '_pagination';
+        $paginator = config('graphql.custom_paginators.' . $name);
+
+        $fields = $paginator ? $paginator::getPaginationFields() : [];
+
         $config = [
             'name'  => $name,
-            'fields' => array_merge($this->getPaginationFields(), [
-                'data' => [
-                    'type'      => GraphQLType::listOf(GraphQL::type($typeName)),
-                    'resolve'   => function(LengthAwarePaginator $data) { return $data->getCollection();  },
-                ],
-            ])
+            'fields' => array_merge(
+                $this->getPaginationFields(),
+                $fields,
+                [
+                    'data' => [
+                        'type'      => GraphQLType::listOf(GraphQL::type($typeName)),
+                        'resolve'   => function(LengthAwarePaginator $data) { return $data->getCollection();  },
+                    ],
+                ]
+            )
         ];
 
         parent::__construct($config);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -139,6 +139,14 @@ return [
         'disable_introspection' => false
     ],
 
+    // You can define custom paginators to override the out-of-the-box fields
+    // Useful if you want to inject some parameters of your own that apply at the top
+    // level of the collection rather than to each instance returned. Can also use this
+    // to add in more of the Laravel pagination data (e.g. last_page).
+    'custom_paginators' => [
+        // 'my_custom_pagination' => \Path\To\Your\CustomPagination::class,
+    ],
+
     /*
      * Config for GraphiQL (see (https://github.com/graphql/graphiql).
      */


### PR DESCRIPTION
Have forked the graphql-laravel repo and added in a tweak to allow us to more easily inject custom fields into the top-level of a paginated response (as needed in the activities query where we want to inject a set of unit totals above the level of the individual activities returned).